### PR TITLE
fix broken livetiming with unusual event number order

### DIFF
--- a/service/event_service.go
+++ b/service/event_service.go
@@ -107,14 +107,14 @@ func GetEventByMeetingAndNumberForLivetiming(id string, number int) (dto.EventLi
 			found = true
 			break
 		}
-		if events[i].Number > number {
-			eventLivetiming.NextEvent = events[i]
-			if i > 0 {
-				eventLivetiming.PrevEvent = events[i-1]
-			}
-			found = true
-			break
-		}
+		//if events[i].Number > number {
+		//	eventLivetiming.NextEvent = events[i]
+		//	if i > 0 {
+		//		eventLivetiming.PrevEvent = events[i-1]
+		//	}
+		//	found = true
+		//	break
+		//}
 	}
 
 	if !found {


### PR DESCRIPTION
[remove code for getting nearest event in livetiming since it results in bugs with strange number orders